### PR TITLE
add: tket compiler for resource estimation

### DIFF
--- a/compare.ipynb
+++ b/compare.ipynb
@@ -583,7 +583,7 @@
    "source": [
     "from pytket.extensions.qiskit import IBMQBackend, tk_to_qiskit, qiskit_to_tk\n",
     "\n",
-    "ibmbackend = IBMQBackend(backend_name=\"ibm_kyiv\")\n",
+    "ibmbackend = IBMQBackend(backend_name=\"ibm_kyiv\")  # Assumes a saved account. \n",
     "tket_circuit = qiskit_to_tk(circuit)\n",
     "\n",
     "tket_compiled = ibmbackend.get_compiled_circuit(circuit=tket_circuit, optimisation_level=3)\n",

--- a/compare.ipynb
+++ b/compare.ipynb
@@ -474,8 +474,7 @@
      "text": [
       "\n",
       "Depth: 5905800\n",
-      "Gates: CX: 5343142, U2: 983896, U1: 635392, RZ: 1953, RX: 124, H: 124\n",
-      "\n"
+      "Gates: CX: 5343142, U2: 983896, U1: 635392, RZ: 1953, RX: 124, H: 124\n"
      ]
     }
    ],
@@ -509,8 +508,7 @@
      "text": [
       "\n",
       "Depth: 4613328\n",
-      "Gates: CX: 4192694, U3: 910838\n",
-      "\n"
+      "Gates: CX: 4192694, U3: 910838\n"
      ]
     }
    ],
@@ -546,10 +544,10 @@
      "evalue": "",
      "output_type": "error",
      "traceback": [
-      "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
-      "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
-      "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
-      "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+      "\u001B[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+      "\u001B[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+      "\u001B[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+      "\u001B[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
      ]
     }
    ],
@@ -568,6 +566,39 @@
     "\"\"\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Compile circuit to device using Quantinuum's TKET"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pytket.extensions.qiskit import IBMQBackend, tk_to_qiskit, qiskit_to_tk\n",
+    "\n",
+    "ibmbackend = IBMQBackend(backend_name=\"ibm_kyiv\")\n",
+    "tket_circuit = qiskit_to_tk(circuit)\n",
+    "\n",
+    "tket_compiled = ibmbackend.get_compiled_circuit(circuit=tket_circuit, optimisation_level=3)\n",
+    "qisk_converted = tk_to_qiskit(tket_compiled)\n",
+    "\n",
+    "print(\n",
+    "    f\"\"\"\n",
+    "Depth: {qisk_converted.depth()}\n",
+    "Gates: {\", \".join([f\"{k.upper()}: {v}\" for k, v in qisk_converted.count_ops().items()])}\n",
+    "\"\"\"\n",
+    ")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,3 @@ qiskit-algorithms==0.3.1
 qiskit-ibm-runtime==0.33.2
 pytket==1.39.0
 pytket-qiskit==0.63.0
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ pyparsing==3.2.0
 qiskit==1.2.4
 qiskit-algorithms==0.3.1
 qiskit-ibm-runtime==0.33.2
+pytket==1.39.0
+pytket-qiskit==0.63.0
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ openfermion==1.6.1
 openfermionpyscf==0.5
 PubChemPy==1.0.4
 pyparsing==3.2.0
-qiskit==1.2.4
+qiskit==1.3.2
 qiskit-algorithms==0.3.1
 qiskit-ibm-runtime==0.33.2
-pytket==1.39.0
 pytket-qiskit==0.63.0


### PR DESCRIPTION
Quantinuum's TKET [default compiler](https://docs.quantinuum.com/tket/extensions/pytket-quantinuum/) is more "aggressive" at optimization level 3 than the Qiskit default compiler at level 3. In particular, I believe that one of the passes of their compiler is strategically designed for circuits resulting from Trotterization. I think that the specific step is [GreedyPaulSimp](https://docs.quantinuum.com/tket/api-docs/passes.html#pytket.passes.GreedyPauliSimp) and it based on [this work](https://arxiv.org/abs/2103.08602). 